### PR TITLE
Update Ubuntu version used in auto-publish.yaml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The version used prior is failing builds like this: https://github.com/explainers-by-googlers/web-scanning/actions/runs/23493685238/job/68368588597#step:3:777

Related issue in the upstream repo of the relevant github action: https://github.com/w3c/spec-prod/issues/191